### PR TITLE
Improve result normalization for pipeline outputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,6 +76,15 @@ class DBFinder:
 
         results = []
 
+        def add_result(item):
+            if item is None:
+                return
+            if isinstance(item, (list, tuple)):
+                for sub_item in item:
+                    add_result(sub_item)
+            else:
+                results.append(item)
+
         def notify(progress, stage):
             if progress_callback:
                 try:
@@ -86,26 +95,26 @@ class DBFinder:
         if classification == "clinical_trials":
             notify(45, "Running ClinicalTrials.gov pipeline")
             console.print("[yellow]Fetching from Clinical Trials...[/yellow]")
-            results.append(run_clinical_trials(query))
+            add_result(run_clinical_trials(query))
 
         elif classification == "open_targets":
             notify(45, "Running Open Targets pipeline")
             console.print("[yellow]Fetching from Open Targets...[/yellow]")
-            results.append(run_open_targets(query))
+            add_result(run_open_targets(query))
 
         elif classification == "both":
             notify(40, "Running ClinicalTrials.gov pipeline")
             console.print("[yellow]Fetching from both sources...[/yellow]")
-            results.append(run_clinical_trials(query))
+            add_result(run_clinical_trials(query))
             notify(65, "Running Open Targets pipeline")
-            results.append(run_open_targets(query))
+            add_result(run_open_targets(query))
 
         elif classification in {"none", "unknown"}:
             notify(40, "Running ClinicalTrials.gov pipeline (fallback)")
             console.print("[yellow]Fallback: querying both data sources...[/yellow]")
-            results.append(run_clinical_trials(query))
+            add_result(run_clinical_trials(query))
             notify(65, "Running Open Targets pipeline (fallback)")
-            results.append(run_open_targets(query))
+            add_result(run_open_targets(query))
             self.last_resolution = "both"
             self.last_rationale += " Fallback executed to cover both pipelines."
 

--- a/webapp/apps/queries/tests/test_services.py
+++ b/webapp/apps/queries/tests/test_services.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pandas as pd
+from django.test import SimpleTestCase
+
+from apps.queries.services import normalize_results
+
+
+class NormalizeResultsTests(SimpleTestCase):
+    def test_dataframe_rows_are_expanded_with_metadata(self) -> None:
+        df = pd.DataFrame([
+            {
+                'title': 'mRNA vaccine trial',
+                'NCT Number': 'NCT12345678',
+                'Status': 'Recruiting',
+                'Condition': 'Lung Cancer',
+                'Interventions': 'Drug A',
+                'Phase': 'Phase 2',
+                'url': 'https://clinicaltrials.gov/study/NCT12345678',
+            }
+        ])
+        df.attrs.update(
+            {
+                'source': 'ClinicalTrials.gov',
+                'title_field': ('title', 'NCT Number'),
+                'summary_field': ('Status',),
+                'link_field': ('url',),
+            }
+        )
+
+        results = normalize_results([df])
+        self.assertEqual(len(results), 1)
+        entry = results[0]
+        self.assertEqual(entry['source'], 'ClinicalTrials.gov')
+        self.assertEqual(entry['title'], 'mRNA vaccine trial')
+        self.assertEqual(entry['summary'], 'Recruiting')
+        self.assertEqual(entry['link'], 'https://clinicaltrials.gov/study/NCT12345678')
+        fields = {item['label']: item['value'] for item in entry['fields']}
+        self.assertEqual(fields['Trial phase'], 'Phase 2')
+        self.assertEqual(fields['Condition'], 'Lung Cancer')
+        self.assertEqual(fields['Interventions'], 'Drug A')
+
+    def test_nested_sequences_and_dicts_normalize(self) -> None:
+        payload = [
+            [
+                {
+                    'source': 'Open Targets',
+                    'name': 'Drug B',
+                    'Mechanism': 'Inhibitor',
+                    'score': 0.82,
+                }
+            ],
+            None,
+        ]
+
+        results = normalize_results(payload)
+        self.assertEqual(len(results), 1)
+        entry = results[0]
+        self.assertEqual(entry['source'], 'Open Targets')
+        self.assertEqual(entry['title'], 'Drug B')
+        fields = {item['label']: item['value'] for item in entry['fields']}
+        self.assertEqual(fields['Mechanism'], 'Inhibitor')
+        self.assertEqual(fields['Score'], '0.82')


### PR DESCRIPTION
## Summary
- flatten router results so multiple pipeline outputs are merged without nested placeholders
- enrich Open Targets and ClinicalTrials.gov pipelines with metadata/links and normalize fields consistently
- harden normalize_results against pandas dataframes, nested payloads, and add unit coverage for the new behavior

## Testing
- python webapp/manage.py test apps.queries

------
https://chatgpt.com/codex/tasks/task_e_68d9b33de5f8832982555bbb8efd1b6e