### PR TITLE
Improve ClinicalTrials.gov retriever robustness

### DIFF
--- a/retriever/Clinical_Trials_Retriever_Agent.py
+++ b/retriever/Clinical_Trials_Retriever_Agent.py
@@ -1,22 +1,71 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
+"""Utilities for retrieving and persisting ClinicalTrials.gov search results."""
+
 import os
 import re
-import requests
+from typing import Dict, List, Optional
+
 import pandas as pd
+import requests
 from rich.console import Console
-from IPython.display import display
+
+try:  # pragma: no cover - optional dependency
+    from IPython.display import display  # type: ignore
+except ImportError:  # pragma: no cover - IPython is optional for the CLI usage
+    display = None
 
 console = Console()
 
-# === Phase Extractor ===
-def extract_phase(query):
-    phase_match = re.search(r"(phase[-\s]*[1-4])", query, re.IGNORECASE)
-    return phase_match.group(1).replace(" ", "-").title() if phase_match else None
+_PHASE_PATTERN = re.compile(
+    r"phase\s*(?:(?P<num>[1-4])|(?P<roman>i{1,3}|iv))",
+    flags=re.IGNORECASE,
+)
+
+
+def extract_phase(query: str) -> Optional[str]:
+    """Extract a clinical trial phase token from a free-text query.
+
+    The ClinicalTrials.gov API expects phases as ``Phase 1`` … ``Phase 4``. Users
+    routinely provide values such as ``phase 2`` or ``Phase II``; this helper
+    normalises those variants into the canonical label. If no phase hint is
+    present ``None`` is returned so the API may broaden the search.
+    """
+
+    if not query:
+        return None
+
+    match = _PHASE_PATTERN.search(query)
+    if not match:
+        return None
+
+    if match.group("num"):
+        phase_number = match.group("num")
+    else:
+        roman = match.group("roman").lower()
+        roman_to_number = {"i": "1", "ii": "2", "iii": "3", "iv": "4"}
+        phase_number = roman_to_number.get(roman)
+        if not phase_number:
+            return None
+
+    return f"Phase {phase_number}"
 
 # === ClinicalTrials.gov Fetcher ===
-def fetch_clinical_trials(condition=None, intervention=None, phase=None, status=None, location=None):
+def fetch_clinical_trials(
+    condition: Optional[str] = None,
+    intervention: Optional[str] = None,
+    phase: Optional[str] = None,
+    status: Optional[str] = None,
+    location: Optional[str] = None,
+    *,
+    page_size: int = 50,
+    timeout: int = 20,
+) -> pd.DataFrame:
+    """Query the ClinicalTrials.gov v2 API and return a DataFrame of studies."""
+
     base_url = "https://clinicaltrials.gov/api/v2/studies"
-    params = {"pageSize": 50}
+    params: Dict[str, str] = {"pageSize": str(page_size)}
     if condition:
         params["query.cond"] = condition
     if intervention:
@@ -26,17 +75,13 @@ def fetch_clinical_trials(condition=None, intervention=None, phase=None, status=
     if location:
         params["query.locn"] = location
 
-    trials = []
+    trials: List[Dict[str, str]] = []
     while True:
         try:
-            response = requests.get(base_url, params=params, timeout=20)
-        except Exception as e:
-            console.log(f"[red]API request error: {e}[/red]")
-            break
-
-        if response.status_code != 200:
-            console.log(f"[red]ClinicalTrials.gov API failed: {response.status_code}[/red]")
-            break
+            response = requests.get(base_url, params=params, timeout=timeout)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise RuntimeError(f"ClinicalTrials.gov request failed: {exc}") from exc
 
         data = response.json()
         studies = data.get("studies", [])
@@ -46,59 +91,86 @@ def fetch_clinical_trials(condition=None, intervention=None, phase=None, status=
         for study in studies:
             protocol = study.get("protocolSection", {})
             identification = protocol.get("identificationModule", {})
-            nctId = identification.get("nctId", "N/A")
-            title = identification.get("briefTitle") or nctId or "Clinical trial"
-            status_val = protocol.get("statusModule", {}).get("overallStatus", "Unknown")
-            conds = ", ".join(protocol.get("conditionsModule", {}).get("conditions", []))
-            interventions = protocol.get("armsInterventionsModule", {}).get("interventions", [])
-            interventions_str = ", ".join([i.get("name", "") for i in interventions]) or "None"
-            phases = ", ".join(protocol.get("designModule", {}).get("phases", []))
-            trial_url = f"https://clinicaltrials.gov/study/{nctId}" if nctId and nctId != "N/A" else ""
+            nct_id = identification.get("nctId", "N/A")
+            title = identification.get("briefTitle") or nct_id or "Clinical trial"
+            status_val = (
+                protocol.get("statusModule", {}).get("overallStatus", "Unknown")
+            )
+            conditions = ", ".join(
+                protocol.get("conditionsModule", {}).get("conditions", [])
+            )
+            interventions = protocol.get("armsInterventionsModule", {}).get(
+                "interventions", []
+            )
+            interventions_str = (
+                ", ".join(intervention.get("name", "") for intervention in interventions)
+                or "None"
+            )
+            phase_labels = protocol.get("designModule", {}).get("phases", [])
+            phases = ", ".join(phase_labels)
+            trial_url = (
+                f"https://clinicaltrials.gov/study/{nct_id}"
+                if nct_id and nct_id != "N/A"
+                else ""
+            )
 
             if phase and phases and phase.lower() not in phases.lower():
                 continue
 
-            trials.append({
-                "title": title,
-                "NCT Number": nctId,
-                "Status": status_val,
-                "Condition": conds,
-                "Interventions": interventions_str,
-                "Phases": phases,
-                "url": trial_url,
-            })
+            trials.append(
+                {
+                    "title": title,
+                    "NCT Number": nct_id,
+                    "Status": status_val,
+                    "Condition": conditions,
+                    "Interventions": interventions_str,
+                    "Phases": phases,
+                    "url": trial_url,
+                }
+            )
 
-        nextPageToken = data.get("nextPageToken")
-        if nextPageToken:
-            params["pageToken"] = nextPageToken
+        next_page_token = data.get("nextPageToken")
+        if next_page_token:
+            params["pageToken"] = next_page_token
         else:
             break
 
     df = pd.DataFrame(trials).drop_duplicates(subset=["NCT Number"])
-    df.attrs.update({
-        "source": "ClinicalTrials.gov",
-        "title_field": ("title", "NCT Number"),
-        "summary_field": ("Status",),
-        "link_field": ("url",),
-    })
+    df.attrs.update(
+        {
+            "source": "ClinicalTrials.gov",
+            "title_field": ("title", "NCT Number"),
+            "summary_field": ("Status",),
+            "link_field": ("url",),
+        }
+    )
     return df
 
 # === Save & Display ===
-def sanitize_filename(name):
-    return re.sub(r'[^A-Za-z0-9_\-\.]', '_', name) if name else None
+def sanitize_filename(name: Optional[str]) -> Optional[str]:
+    """Return a filesystem-safe filename derived from ``name``."""
 
-def display_and_save_results(df, filename):
+    return re.sub(r"[^A-Za-z0-9_\-\.]", "_", name) if name else None
+
+def display_and_save_results(df: pd.DataFrame, filename: str) -> str:
+    """Persist the DataFrame to disk and render it if an IPython display exists."""
+
     os.makedirs("output", exist_ok=True)
-    filepath = os.path.join("output", sanitize_filename(filename) or "trials_results.csv")
-    try:
-        display(df)
-    except Exception:
-        console.log("[yellow]Could not render dataframe; continuing.[/yellow]")
+    sanitized = sanitize_filename(filename) or "trials_results.csv"
+    filepath = os.path.join("output", sanitized)
+
+    if display is not None:
+        try:  # pragma: no cover - requires IPython rich repr
+            display(df)
+        except Exception:
+            console.log("[yellow]Could not render dataframe; continuing.[/yellow]")
+
     df.to_csv(filepath, index=False)
     console.log(f"[green]Trials saved to {filepath}[/green]")
+    return filepath
 
 # === Retriever Agent ===
-def retrieve_trials(parsed_query: dict, original_query: str):
+def retrieve_trials(parsed_query: Dict[str, Optional[str]], original_query: str) -> pd.DataFrame:
     console.rule("[bold magenta]Retriever Agent[/bold magenta]")
 
     condition = parsed_query.get("Condition/Disease")
@@ -112,16 +184,15 @@ def retrieve_trials(parsed_query: dict, original_query: str):
     parts = [str(x) for x in [condition, drug, phase] if x]
     filename = "_".join(parts) + "_trials.csv" if parts else "trials_results.csv"
 
-    # ?? Always initialize df (empty by default)
-    df = pd.DataFrame()
-
     try:
         df = fetch_clinical_trials(condition, drug, phase, status, location)
-        if not df.empty:
-            display_and_save_results(df, filename)
-        else:
-            console.log("[yellow]No trials found for this query.[/yellow]")
-    except Exception as e:
-        console.log(f"[red]Retriever failed: {e}[/red]")
+    except RuntimeError as exc:
+        console.log(f"[red]Retriever failed: {exc}[/red]")
+        return pd.DataFrame()
 
+    if df.empty:
+        console.log("[yellow]No trials found for this query.[/yellow]")
+        return df
+
+    display_and_save_results(df, filename)
     return df

--- a/retriever/Clinical_Trials_Retriever_Agent.py
+++ b/retriever/Clinical_Trials_Retriever_Agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import re
+from json import JSONDecodeError
 from typing import Dict, List, Optional
 
 import pandas as pd
@@ -83,7 +84,12 @@ def fetch_clinical_trials(
         except requests.RequestException as exc:
             raise RuntimeError(f"ClinicalTrials.gov request failed: {exc}") from exc
 
-        data = response.json()
+        try:
+            data = response.json()
+        except (ValueError, JSONDecodeError) as exc:
+            raise RuntimeError(
+                "ClinicalTrials.gov returned invalid JSON payload"
+            ) from exc
         studies = data.get("studies", [])
         if not studies:
             break

--- a/webapp/apps/queries/tests/test_clinical_trials_retriever.py
+++ b/webapp/apps/queries/tests/test_clinical_trials_retriever.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pandas as pd
+from django.test import SimpleTestCase
+
+from retriever.Clinical_Trials_Retriever_Agent import (
+    display_and_save_results,
+    extract_phase,
+    sanitize_filename,
+)
+
+
+class ExtractPhaseTests(SimpleTestCase):
+    def test_returns_none_when_no_phase_present(self) -> None:
+        self.assertIsNone(extract_phase("Latest immunotherapy approaches"))
+
+    def test_extracts_numeric_phase(self) -> None:
+        self.assertEqual(extract_phase("Need phase 3 lung cancer trials"), "Phase 3")
+
+    def test_extracts_roman_phase(self) -> None:
+        self.assertEqual(extract_phase("looking for Phase II studies"), "Phase 2")
+
+
+class SanitizeFilenameTests(SimpleTestCase):
+    def test_replaces_illegal_characters(self) -> None:
+        self.assertEqual(sanitize_filename("lung cancer?:phase 2"), "lung_cancer__phase_2")
+
+    def test_returns_none_for_empty_values(self) -> None:
+        self.assertIsNone(sanitize_filename(None))
+
+
+class DisplayAndSaveResultsTests(SimpleTestCase):
+    def test_writes_csv_and_returns_path(self) -> None:
+        df = pd.DataFrame([{"title": "trial", "NCT Number": "NCT1"}])
+        filename = "trial:results.csv"
+
+        output_path = display_and_save_results(df, filename)
+
+        try:
+            self.assertTrue(Path(output_path).exists())
+            with open(output_path, "r", encoding="utf-8") as handle:
+                contents = handle.read()
+            self.assertIn("NCT1", contents)
+            self.assertTrue(output_path.endswith("trial_results.csv"))
+        finally:
+            if os.path.exists(output_path):
+                os.remove(output_path)


### PR DESCRIPTION
## Summary
- normalize phase parsing, harden ClinicalTrials.gov API calls, and make CSV persistence safer
- make the IPython display dependency optional while preserving result metadata
- add unit tests covering phase extraction, filename sanitization, and CSV persistence helpers

## Testing
- python webapp/manage.py test apps.queries

------
https://chatgpt.com/codex/tasks/task_e_68d9b624597c8329b02dff5c741f7cc1